### PR TITLE
[API] Implement describeAgent in AgentService

### DIFF
--- a/plans/P005-implement-describe-agent.md
+++ b/plans/P005-implement-describe-agent.md
@@ -1,0 +1,61 @@
+# P005 - Implement describeAgent in AgentService
+
+## Context
+The `AgentService.describeAgent` method in `src/main/java/br/cefetmg/lsi/bimasco/api/AgentService.java` is currently unimplemented. Users cannot retrieve detailed metrics for individual agents.
+
+## Goals
+- Implement the `describeAgent` gRPC method.
+- Update `AgentActor` to provide its internal state.
+- Ensure all required metrics (lifetime, startTime, currentTime, completeExecutions, bestSolution, and memory) are returned.
+
+## Technical Approach
+
+### 1. Update Messages in `Messages.java`
+- Modify `GetState` to extend `AbstractMessage` so it can be handled by `MessageExtractor`.
+- Add `DetailedAgentState` class to carry the state data from the actor to the service.
+
+### 2. Update `AgentActor.java`
+- Add `startTime` field and initialize it in `onStartSimulation`.
+- Update `onGetState` to return `DetailedAgentState`.
+- `DetailedAgentState` should include:
+    - `lifetime`: from `agentSettings`
+    - `startTime`: the time when simulation started for this agent.
+    - `currentTime`: `globalTime`.
+    - `completeExecutions`: `agent.getContext().getInvocations().get()`.
+    - `bestSolution`: `agent.getContext().getBestSolution()`.
+    - `memory`: from `agent.getQLearningMemory().getQTable()`.
+    - `memoryTax`: `agent.getAgentSettings().getMemoryTax()`.
+    - `requiredSolutions`: `agent.getSolutionsCount()`.
+    - `heuristic`: `agent.getAgentSettings().getMetaHeuristicName()`.
+
+### 3. Implement `AgentService.java`
+- Implement `describeAgent` method.
+- Parse `agentId` (e.g., "agent-0") to get the numeric ID.
+- Use `Patterns.ask` to send `GetState` to `agentShard`.
+- Convert `DetailedAgentState` to `DescribeAgentResponse`.
+
+## Tasks
+- [x] Create `DetailedAgentState` in `Messages.java` and update `GetState`.
+- [x] Update `AgentActor` to track `startTime` and handle `GetState` returning `DetailedAgentState`.
+- [x] Implement `AgentService.describeAgent`.
+- [x] Add tests to verify the implementation.
+
+## Dependencies
+- gRPC and Protobuf (already in place).
+- Akka actors and sharding (already in place).
+
+## Design Decisions
+- `GetState` needs to be an `AbstractMessage` to be easily sent to a specific agent through the shard region without having to know the direct `ActorRef`.
+- `DetailedAgentState` is a plain Java object (Serializable) to facilitate communication between the actor and the service.
+
+## Verification Plan
+
+### Test Cases
+1. **AgentActor State:**
+    - Test that `AgentActor` responds to `GetState` with a `DetailedAgentState` containing correct values.
+2. **AgentService describeAgent:**
+    - Test that `AgentService.describeAgent` correctly communicates with the actor and returns the expected gRPC response.
+
+### Automated Tests
+- Create `src/test/java/br/cefetmg/lsi/bimasco/actors/AgentActorTest.java` (if not exists) or add to it.
+- Create `src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java` (if not exists) or add to it.

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
                 </dependencies>
                 <configuration>
                     <forkMode>once</forkMode>
-                    <argLine>-Djava.library.path=${project.basedir}/native/</argLine>
+                    <argLine>-Djava.library.path=${project.basedir}/native/ --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <propertyName>java.library.path</propertyName>
                         <buildDirectory>native/</buildDirectory>

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/AgentActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/AgentActor.java
@@ -68,6 +68,8 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
 
     private long globalTime;
 
+    private long startTime;
+
     private long globalSolutions;
 
     private Cancellable internalTask;
@@ -131,6 +133,7 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
         logger.info("Handling start simulation " + startSimulation);
         startSimulation.problem.ifPresent(agent::reset);
         agentStarted = true;
+        startTime = globalTime;
         globalSolutions = 0;
         startInternalTask();
     }
@@ -236,7 +239,23 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
     }
 
     public void onGetState(GetState state){
-        sender().tell(new AgentState(), self());
+        if (agent == null) {
+            sender().tell(new akka.actor.Status.Failure(new IllegalStateException("Agent not initialized yet")), self());
+            return;
+        }
+
+        sender().tell(new DetailedAgentState(
+                persistenceId(),
+                lifetime,
+                startTime,
+                globalTime,
+                agent.getContext().getInvocations().get(),
+                (long) agent.getSolutionsCount(),
+                agent.getAgentSettings().getMetaHeuristicName(),
+                agent.getAgentSettings().getMemoryTax(),
+                agent.getContext().getBestSolution(),
+                agent.getQLearningMemory().getQTable()
+        ), self());
     }
 
     private void processSolutionList(int region, List<Solution> solutions) {

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/MainActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/MainActor.java
@@ -3,6 +3,7 @@ package br.cefetmg.lsi.bimasco.actors;
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.cluster.sharding.ClusterSharding;
 import br.cefetmg.lsi.bimasco.api.AgentService;
 import br.cefetmg.lsi.bimasco.api.BenchmarkService;
 import br.cefetmg.lsi.bimasco.api.RegionService;
@@ -15,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static br.cefetmg.lsi.bimasco.actors.Messages.*;
 
@@ -49,8 +51,13 @@ public class MainActor extends AbstractActor {
             simulationActor = context().actorOf(Props.create(SimulationActor.class, settings), "manager");
         }
 
+        ActorRef agentShard = ClusterSharding.get(context().system()).startProxy(
+                "agents",
+                Optional.empty(),
+                Messages.agentMessageExtractor);
+
         grpcServer = ServerBuilder.forPort(8080)
-                .addService(new AgentService(simulationActor))
+                .addService(new AgentService(simulationActor, agentShard))
                 .addService(new RegionService(simulationActor))
                 .addService(new BenchmarkService(benchmarkActor))
                 .addService(new SimulationService(simulationActor))

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/Messages.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/Messages.java
@@ -266,7 +266,43 @@ public class Messages {
         }
     }
 
-    public static class GetState implements Serializable {}
+    public static class GetState extends AbstractMessage {
+        public GetState(int receiverId) {
+            super(Messages.Nobody, receiverId);
+        }
+
+        public GetState() {
+            super(Messages.Nobody, Messages.Nobody);
+        }
+    }
+
+    public static class DetailedAgentState implements Serializable {
+        public final String agentId;
+        public final long lifetime;
+        public final long startTime;
+        public final long currentTime;
+        public final long completeExecutions;
+        public final long requiredSolutions;
+        public final String heuristic;
+        public final double memoryTax;
+        public final Solution bestSolution;
+        public final Map<Integer, Double> qTable;
+
+        public DetailedAgentState(String agentId, long lifetime, long startTime, long currentTime,
+                                  long completeExecutions, long requiredSolutions, String heuristic,
+                                  double memoryTax, Solution bestSolution, Map<Integer, Double> qTable) {
+            this.agentId = agentId;
+            this.lifetime = lifetime;
+            this.startTime = startTime;
+            this.currentTime = currentTime;
+            this.completeExecutions = completeExecutions;
+            this.requiredSolutions = requiredSolutions;
+            this.heuristic = heuristic;
+            this.memoryTax = memoryTax;
+            this.bestSolution = bestSolution;
+            this.qTable = qTable;
+        }
+    }
 
     public static class Terminate implements Serializable {}
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/api/AgentService.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/api/AgentService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 public class AgentService extends AgentServiceGrpc.AgentServiceImplBase {
@@ -21,9 +22,11 @@ public class AgentService extends AgentServiceGrpc.AgentServiceImplBase {
     private static final Logger logger = LoggerFactory.getLogger(AgentService.class);
 
     private ActorRef simulationActor;
+    private ActorRef agentShard;
 
-    public AgentService(ActorRef simulationActor) {
+    public AgentService(ActorRef simulationActor, ActorRef agentShard) {
         this.simulationActor = simulationActor;
+        this.agentShard = agentShard;
     }
 
     private CompletableFuture<SimulationState> getSimulationState() {
@@ -63,6 +66,46 @@ public class AgentService extends AgentServiceGrpc.AgentServiceImplBase {
 
     @Override
     public void describeAgent(DescribeAgentRequest request, StreamObserver<DescribeAgentResponse> responseObserver) {
-        super.describeAgent(request, responseObserver);
+        logger.info("Doptimas API describeAgent request {}", request);
+        String agentId = request.getAgentId();
+        int id = Integer.parseInt(agentId.split("-")[1]);
+
+        Patterns.ask(agentShard, new Messages.GetState(id), Duration.ofSeconds(5))
+                .toCompletableFuture()
+                .thenAccept(obj -> {
+                    if (obj instanceof Messages.DetailedAgentState) {
+                        Messages.DetailedAgentState state = (Messages.DetailedAgentState) obj;
+                        DescribeAgentResponse.Builder builder = DescribeAgentResponse.newBuilder()
+                                .setAgentId(state.agentId)
+                                .setLifetime(state.lifetime)
+                                .setStartTime(state.startTime)
+                                .setCurrentTime(state.currentTime)
+                                .setCompleteExecutions(state.completeExecutions)
+                                .setRequiredSolutions(state.requiredSolutions)
+                                .setHeuristic(state.heuristic)
+                                .setMemoryTax(state.memoryTax)
+                                .putAllMemory(state.qTable.entrySet().stream()
+                                        .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)));
+
+                        if (state.bestSolution != null) {
+                            List<Double> x = DoubleStream.of(state.bestSolution.toDoubleArray()).boxed().collect(Collectors.toList());
+                            List<Double> y = List.of(state.bestSolution.getFunctionValue().doubleValue());
+
+                            builder.setBestSolution(Solution.newBuilder()
+                                    .setId(state.bestSolution.getId().toString())
+                                    .addAllX(x)
+                                    .addAllY(y)
+                                    .build());
+                        }
+
+                        responseObserver.onNext(builder.build());
+                        responseObserver.onCompleted();
+                    } else {
+                        responseObserver.onError(new RuntimeException("Unexpected response from agent: " + obj));
+                    }
+                }).exceptionally(ex -> {
+                    responseObserver.onError(ex);
+                    return null;
+                });
     }
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/core/agents/Agent.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/core/agents/Agent.java
@@ -130,6 +130,10 @@ public class Agent implements Serializable {
         return new MemoryState(problem.toString(), agentSettings.getName(), regions, probabilities, bestMemorySolution);
     }
 
+    public QLearningMemory getQLearningMemory() {
+        return qLearningMemory;
+    }
+
     public void reset(Problem problem) {
         this.problem = problem;
         metaHeuristic.setProblem(problem);

--- a/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
+++ b/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
@@ -1,0 +1,183 @@
+package br.cefetmg.lsi.bimasco.api;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.cluster.Cluster;
+import akka.cluster.sharding.ClusterSharding;
+import akka.testkit.javadsl.TestKit;
+import br.cefetmg.lsi.bimasco.actors.MainActor;
+import br.cefetmg.lsi.bimasco.actors.Messages;
+import br.cefetmg.lsi.bimasco.settings.SimulationSettings;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import br.cefetmg.lsi.bimasco.api.AgentServiceGrpc;
+import br.cefetmg.lsi.bimasco.api.DescribeAgentRequest;
+import br.cefetmg.lsi.bimasco.api.DescribeAgentResponse;
+import br.cefetmg.lsi.bimasco.api.SimulationServiceGrpc;
+import br.cefetmg.lsi.bimasco.api.StartSimulationRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AgentServiceTest {
+    private static ActorSystem system;
+    private static Server server;
+    private static ManagedChannel channel;
+    private static AgentServiceGrpc.AgentServiceBlockingStub agentBlockingStub;
+    private static SimulationServiceGrpc.SimulationServiceBlockingStub simulationBlockingStub;
+    private static ActorRef simulationActor;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        String akkaConfig = "akka {\n" +
+                "  actor.provider = \"cluster\"\n" +
+                "  remote.artery {\n" +
+                "    canonical.hostname = \"127.0.0.1\"\n" +
+                "    canonical.port = 0\n" +
+                "  }\n" +
+                "  persistence {\n" +
+                "    journal.plugin = \"akka.persistence.journal.inmem\"\n" +
+                "    snapshot-store.plugin = \"akka.persistence.snapshot-store.local\"\n" +
+                "    snapshot-store.local.dir = \"target/snapshots\"\n" +
+                "  }\n" +
+                "  cluster.sharding.state-store-mode = \"ddata\"\n" +
+                "  cluster.sharding.distributed-data.durable.keys = []\n" +
+                "}";
+
+        system = ActorSystem.create("TestSystem", ConfigFactory.parseString(akkaConfig).withFallback(ConfigFactory.load()));
+
+        Cluster cluster = Cluster.get(system);
+        cluster.join(cluster.selfAddress());
+
+        String agentConfig = "{\n" +
+                "  name: \"TestGRASP\",\n" +
+                "  count: 1,\n" +
+                "  metaHeuristicName: \"GRASP\",\n" +
+                "  isPopulationMetaHeuristic: false,\n" +
+                "  isConstructorMetaHeuristic: true,\n" +
+                "  lifetime: 1000,\n" +
+                "  memoryTax: 0.5,\n" +
+                "  metaHeuristicParameters: {\n" +
+                "    maxIterations = 20\n" +
+                "    maxIterationsSM = 5\n" +
+                "    time = 100.0\n" +
+                "    f0 = -1.7723\n" +
+                "    alpha = 0.001\n" +
+                "    stopConditionName = \"MaxIterations\"\n" +
+                "    neighborsListName = \"Step\"\n" +
+                "    localSearchName = \"Random\"\n" +
+                "    localSearchNeighbor = \"RealRandom\"\n" +
+                "    candidatesListName = \"Function\"\n" +
+                "  }\n" +
+                "}";
+
+        String configString = TestConfigHelper.buildSimulationConfig("Test", 60, 1, "results",
+                TestConfigHelper.buildProblemConfig("Function", "Function", false,
+                        "br.cefetmg.lsi.bimasco.core.problems.FunctionProblem", "Function",
+                        List.of(
+                                List.of("Michalewicz"), List.of(2), List.of(0.1),
+                                List.of(0.000001, 0.000001), List.of(0.0, 3.141592), List.of(0.0, 3.141592)
+                        )),
+                TestConfigHelper.buildRegionConfig(10, 1, 10),
+                List.of(agentConfig));
+
+        Config config = ConfigFactory.parseString(configString);
+        SimulationSettings settings = new SimulationSettings(config);
+
+        ActorRef mainActor = system.actorOf(Props.create(MainActor.class), "main");
+        mainActor.tell(settings, ActorRef.noSender());
+
+        // Wait for SimulationActor to be created by MainActor
+        int retries = 0;
+        while (simulationActor == null && retries < 10) {
+            try {
+                simulationActor = system.actorSelection("/user/main/manager").resolveOne(Duration.ofSeconds(1)).toCompletableFuture().join();
+            } catch (Exception e) {
+                try { Thread.sleep(1000); } catch (InterruptedException ex) {}
+                retries++;
+            }
+        }
+        assertNotNull(simulationActor, "SimulationActor should be created by MainActor");
+
+        ActorRef agentShard = ClusterSharding.get(system).startProxy(
+                "agents",
+                Optional.empty(),
+                Messages.agentMessageExtractor);
+
+        server = ServerBuilder.forPort(0)
+                .addService(new AgentService(simulationActor, agentShard))
+                .addService(new SimulationService(simulationActor))
+                .build()
+                .start();
+
+        channel = ManagedChannelBuilder.forAddress("localhost", server.getPort())
+                .usePlaintext()
+                .build();
+
+        agentBlockingStub = AgentServiceGrpc.newBlockingStub(channel);
+        simulationBlockingStub = SimulationServiceGrpc.newBlockingStub(channel);
+    }
+
+    @AfterAll
+    public static void teardown() throws InterruptedException {
+        if (channel != null) channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        if (server != null) server.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        if (system != null) TestKit.shutdownActorSystem(system);
+    }
+
+    @Test
+    public void testDescribeAgent() throws InterruptedException {
+        // 1. Start simulation to ensure agents are created
+        simulationBlockingStub.startSimulation(StartSimulationRequest.newBuilder().build());
+
+        // 2. Describe agent-0 (with retry)
+        DescribeAgentRequest request = DescribeAgentRequest.newBuilder()
+                .setAgentId("agent-0")
+                .build();
+
+        DescribeAgentResponse response = null;
+        int retries = 0;
+        while (response == null && retries < 20) {
+            try {
+                DescribeAgentResponse temp = agentBlockingStub.describeAgent(request);
+                // Wait until it has a best solution
+                if (temp.hasBestSolution()) {
+                    response = temp;
+                } else {
+                    System.out.println("Retry " + retries + ": No best solution yet");
+                    Thread.sleep(1000);
+                    retries++;
+                }
+            } catch (Exception e) {
+                System.out.println("Retry " + retries + " failed: " + e.getMessage());
+                Thread.sleep(1000);
+                retries++;
+            }
+        }
+
+        assertNotNull(response, "Response should not be null after retries");
+        assertEquals("agent-0", response.getAgentId());
+        assertEquals("GRASP", response.getHeuristic());
+        assertEquals(1000, response.getLifetime());
+        assertEquals(0.5, response.getMemoryTax(), 0.0001);
+        assertTrue(response.getCurrentTime() >= 0);
+        assertTrue(response.getStartTime() >= 0);
+        assertNotNull(response.getMemoryMap());
+        assertTrue(response.hasBestSolution());
+        assertNotNull(response.getBestSolution().getId());
+    }
+}

--- a/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
+++ b/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -63,27 +64,20 @@ public class AgentServiceTest {
         Cluster cluster = Cluster.get(system);
         cluster.join(cluster.selfAddress());
 
-        String agentConfig = "{\n" +
-                "  name: \"TestGRASP\",\n" +
-                "  count: 1,\n" +
-                "  metaHeuristicName: \"GRASP\",\n" +
-                "  isPopulationMetaHeuristic: false,\n" +
-                "  isConstructorMetaHeuristic: true,\n" +
-                "  lifetime: 1000,\n" +
-                "  memoryTax: 0.5,\n" +
-                "  metaHeuristicParameters: {\n" +
-                "    maxIterations = 20\n" +
-                "    maxIterationsSM = 5\n" +
-                "    time = 100.0\n" +
-                "    f0 = -1.7723\n" +
-                "    alpha = 0.001\n" +
-                "    stopConditionName = \"MaxIterations\"\n" +
-                "    neighborsListName = \"Step\"\n" +
-                "    localSearchName = \"Random\"\n" +
-                "    localSearchNeighbor = \"RealRandom\"\n" +
-                "    candidatesListName = \"Function\"\n" +
-                "  }\n" +
-                "}";
+        String agentConfig = TestConfigHelper.buildAgentConfig("TestGRASP", 1, "GRASP",
+                false, true, 1000, 0.5,
+                Map.of(
+                        "maxIterations", 20,
+                        "maxIterationsSM", 5,
+                        "time", 100.0,
+                        "f0", -1.7723,
+                        "alpha", 0.001,
+                        "stopConditionName", "MaxIterations",
+                        "neighborsListName", "Step",
+                        "localSearchName", "Random",
+                        "localSearchNeighbor", "RealRandom",
+                        "candidatesListName", "Function"
+                ));
 
         String configString = TestConfigHelper.buildSimulationConfig("Test", 60, 1, "results",
                 TestConfigHelper.buildProblemConfig("Function", "Function", false,

--- a/src/test/java/br/cefetmg/lsi/bimasco/api/TestConfigHelper.java
+++ b/src/test/java/br/cefetmg/lsi/bimasco/api/TestConfigHelper.java
@@ -1,6 +1,7 @@
 package br.cefetmg.lsi.bimasco.api;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TestConfigHelper {
@@ -27,6 +28,27 @@ public class TestConfigHelper {
                 "  problem: " + problem + ",\n" +
                 "  region: " + region + ",\n" +
                 "  agents: [" + String.join(", ", agents) + "]\n" +
+                "}";
+    }
+
+    public static String buildAgentConfig(String name, int count, String metaHeuristicName,
+                                        boolean isPopulation, boolean isConstructor, long lifetime,
+                                        double memoryTax, Map<String, Object> parameters) {
+        String params = parameters.entrySet().stream()
+                .map(e -> e.getKey() + " = " + (e.getValue() instanceof String ? "\"" + e.getValue() + "\"" : e.getValue()))
+                .collect(Collectors.joining("\n        "));
+
+        return "{\n" +
+                "  name: \"" + name + "\",\n" +
+                "  count: " + count + ",\n" +
+                "  metaHeuristicName: \"" + metaHeuristicName + "\",\n" +
+                "  isPopulationMetaHeuristic: " + isPopulation + ",\n" +
+                "  isConstructorMetaHeuristic: " + isConstructor + ",\n" +
+                "  lifetime: " + lifetime + ",\n" +
+                "  memoryTax: " + memoryTax + ",\n" +
+                "  metaHeuristicParameters: {\n" +
+                "    " + params + "\n" +
+                "  }\n" +
                 "}";
     }
 


### PR DESCRIPTION
### Context
The AgentService.describeAgent method was unimplemented. This PR provides a full implementation allowing users to retrieve detailed metrics for individual agents.

### Technical Approach
- Updated `Messages.java` to include `DetailedAgentState` and modified `GetState` for sharded routing.
- Updated `AgentActor.java` to track `startTime` and provide detailed state including `bestSolution` and Q-Table memory.
- Implemented `AgentService.describeAgent` using Akka `Patterns.ask` to query agents.
- Updated `MainActor.java` to use `startProxy` for the agent shard to avoid initialization race conditions.
- Updated `pom.xml` with JVM arguments for Java 21+ compatibility.

### Classes modified
- `AgentService.java`
- `AgentActor.java`
- `Messages.java`
- `Agent.java`
- `MainActor.java`
- `pom.xml`

### Verification Results
- Created `AgentServiceTest.java` which successfully verifies that `describeAgent` returns all requested metrics (heuristic, lifetime, bestSolution, etc.) for a sharded agent.

Closes #12