### PR TITLE
feat: improve server management and COCO benchmark isolation

### DIFF
--- a/docker/docker-stack.yml
+++ b/docker/docker-stack.yml
@@ -8,6 +8,8 @@ networks:
 services:
   d-optimas:
     image: felipedreis/d-optimas:2.10
+    ports:
+      - "8080:8080"
     environment:
       DOPTIMAS_PORT: 2551
       DOPTIMAS_EXP_FILE: experiments/artigo/COCO.conf
@@ -15,8 +17,10 @@ services:
       REPEAT: 1
     # Use dns_rr for tasks discovery
     deploy:
-      replicas: 4
+      replicas: 1
       placement:
+        constraints:
+          - node.role == manager
         max_replicas_per_node: 1
       restart_policy:
         condition: on-failure
@@ -31,12 +35,10 @@ services:
       - d-optimas-net
 
   cassandra:
-    image: bitnami/cassandra:3.11.5
+    image: cassandra:3.11
     environment:
-      - CASSANDRA_HOST=cassandra
-      - CASSANDRA_DATACENTER=datacenter1
+      - CASSANDRA_DC=datacenter1
       - CASSANDRA_CLUSTER_NAME=d-optimas-db
-      - CASSANDRA_PASSWORD_SEEDER=yes
       - MAX_HEAP_SIZE=512M
       - HEAP_NEWSIZE=100M
     deploy:

--- a/src/main/java/br/cefetmg/lsi/bimasco/Main.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/Main.java
@@ -31,13 +31,11 @@ public class Main {
         Option host = Option.builder("host")
                 .hasArg()
                 .argName("ip")
-                .required()
                 .build();
 
         Option config = Option.builder("config")
                 .hasArg()
                 .argName("file")
-                .required()
                 .build();
 
 
@@ -74,37 +72,42 @@ public class Main {
                 System.exit(0);
             }
 
-            String host = cmd.getOptionValue("host");
+            String host = cmd.getOptionValue("host", "127.0.0.1");
             Config config = ConfigFactory.load();
 
             DatabaseHelper.initCqlSession(host);
 
-            File configFile = new File(cmd.getOptionValue("config"));
-            Config simulationConfig = ConfigFactory.parseFile(configFile);
-            SimulationSettings settings = new SimulationSettings(simulationConfig);
+            ActorSystem system = ActorSystem.create("d-optimas", config);
 
-            if (cmd.hasOption("extract")){
-                logger.info("Received extract option, I won't run any simulation");
-                DOptimasMapper mapper = DatabaseHelper.getMapper();
-                logger.info("Building extract beans");
-                ExtractorsConfig extractorsConfig = new ExtractorsConfig(mapper.agentStateDAO(), mapper.regionStateDAO(),
-                        mapper.solutionStateDAO(), mapper.globalStateDAO(), mapper.messageStateDAO(), mapper.memoryStateDAO());
-                extractorsConfig.setProblemId(settings.getName());
+            DatabaseCleaner cleaner = new DatabaseCleaner();
+            cleaner.cleanup(system);
+            ActorRef mainActor = system.actorOf(Props.create(MainActor.class), "main");
 
-                logger.info("Creating data extraction batch");
-                DataExtractionBatch extractionBatch = new DataExtractionBatch(settings.getExtractPath() + "/",
-                        extractorsConfig.extractors());
-                logger.info("Starting data extraction batch");
-                extractionBatch.prepareDataPath();
-                extractionBatch.run();
+            if (cmd.hasOption("config")) {
+                File configFile = new File(cmd.getOptionValue("config"));
+                Config simulationConfig = ConfigFactory.parseFile(configFile);
+                SimulationSettings settings = new SimulationSettings(simulationConfig);
+
+                if (cmd.hasOption("extract")){
+                    logger.info("Received extract option, I won't run any simulation");
+                    DOptimasMapper mapper = DatabaseHelper.getMapper();
+                    logger.info("Building extract beans");
+                    ExtractorsConfig extractorsConfig = new ExtractorsConfig(mapper.agentStateDAO(), mapper.regionStateDAO(),
+                            mapper.solutionStateDAO(), mapper.globalStateDAO(), mapper.messageStateDAO(), mapper.memoryStateDAO());
+                    extractorsConfig.setProblemId(settings.getName());
+
+                    logger.info("Creating data extraction batch");
+                    DataExtractionBatch extractionBatch = new DataExtractionBatch(settings.getExtractPath() + "/",
+                            extractorsConfig.extractors());
+                    logger.info("Starting data extraction batch");
+                    extractionBatch.prepareDataPath();
+                    extractionBatch.run();
+                } else {
+                    DatabaseHelper.clearAllTables();
+                    mainActor.tell(settings, ActorRef.noSender());
+                }
             } else {
-                DatabaseHelper.clearAllTables();
-                ActorSystem system = ActorSystem.create("d-optimas", config);
-
-                DatabaseCleaner cleaner = new DatabaseCleaner();
-                cleaner.cleanup(system);
-                ActorRef mainActor = system.actorOf(Props.create(MainActor.class), "main");
-                mainActor.tell(settings, mainActor);
+                logger.info("D-Optimas started in dormant mode. Waiting for configuration.");
             }
         } catch (ParseException e) {
             e.printStackTrace();

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/AgentActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/AgentActor.java
@@ -57,6 +57,7 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
     private ActorRef agentsShard;
     private ActorRef regionsShard;
     private int id;
+    private String problemId;
 
     private AgentStateDAO agentStateDAO;
     private MessageStateDAO messageStateDAO;
@@ -109,7 +110,9 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
                     regionsShard = snapshot.regionsShard;
                     lifetime = agent.getAgentSettings().getLifetime();
 
-                    leader.tell(new AgentRegister(id, self()), self());
+                    AgentRegister register = new AgentRegister(id, self());
+                    register.withProblemId(problemId);
+                    leader.tell(register, self());
                 })
                 .build();
     }
@@ -182,7 +185,7 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
 
     private void initialize(CreateAgent c) {
         logger.info("Running initialize for " + persistenceId());
-
+        this.problemId = c.problemId;
         agentsShard = c.agentsShard;
         regionsShard = c.regionsShard;
         leader = c.leader;
@@ -193,7 +196,9 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
     private Object onCreateAgent(CreateAgent createAgent){
         logger.info("{} {}", sender(), createAgent);
         initialize(createAgent);
-        sender().tell(new AgentRegister(id, self()), self());
+        AgentRegister register = new AgentRegister(id, self());
+        register.withProblemId(problemId);
+        sender().tell(register, self());
         saveSnapshot(new AgentActorSnapshot(agent, agentsShard, regionsShard, leader));
         return null;
     }
@@ -222,7 +227,9 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
             Optional<Integer> regionOptional = agent.chooseRegion();
 
             if (regionOptional.isPresent()) {
-                regionsShard.tell(new SolutionRequest(id, regionOptional.get(), agent.getSolutionsCount()), self());
+                SolutionRequest request = new SolutionRequest(id, regionOptional.get(), agent.getSolutionsCount());
+                request.withProblemId(problemId);
+                regionsShard.tell(request, self());
                 logger.info(join("Sending solution request to region ", regionOptional.get()));
 
                 MemoryState memoryState = agent.getMemoryState();
@@ -232,7 +239,9 @@ public class AgentActor extends AbstractPersistentActor implements Serializable,
                 memoryState.setChosenRegion(regionOptional.get());
                 persistMemoryState(memoryState);
             } else {
-                leader.tell(new SolutionRequest(id, Messages.Nobody, agent.getSolutionsCount()), self());
+                SolutionRequest request = new SolutionRequest(id, Messages.Nobody, agent.getSolutionsCount());
+                request.withProblemId(problemId);
+                leader.tell(request, self());
                 logger.info("Sending solution request to the leader");
             }
         }

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/BenchmarkActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/BenchmarkActor.java
@@ -43,6 +43,10 @@ public class BenchmarkActor extends AbstractActor {
 
     private ExtractorsConfig extractorsConfig;
 
+    private br.cefetmg.lsi.bimasco.settings.SimulationSettings simulationSettings;
+
+    public BenchmarkActor() {}
+
     public BenchmarkActor(ActorRef simulationActor, String name, long evaluationsBudget){
         this.simulationActor = simulationActor;
         this.name = name;
@@ -52,10 +56,15 @@ public class BenchmarkActor extends AbstractActor {
     @Override
     public void preStart() throws Exception {
         super.preStart();
-        init();
+        if (name != null) {
+            init();
+        }
     }
     private void init() {
         try {
+            if (coCOBenchmark != null) {
+                stopBenchmark();
+            }
             suite = new Suite(name, name, "");
             observer = new Observer(name, "");
 
@@ -66,6 +75,8 @@ public class BenchmarkActor extends AbstractActor {
                     mapper.globalStateDAO(), mapper.messageStateDAO(), mapper.memoryStateDAO());
 
             problemCounter = 0;
+            evaluations = 0;
+            runningSimulation = false;
         } catch (Exception ex) {
             logger.error("Failed to initialize benchmark", ex);
         }
@@ -74,9 +85,19 @@ public class BenchmarkActor extends AbstractActor {
     public Receive createReceive() {
         return receiveBuilder()
                 .match(Evaluate.class, this::handleEvaluate)
+                .match(ConfigureSimulation.class, this::onConfigureSimulation)
                 .match(StartSimulation.class, this::startBenchmark)
                 .match(SimulationStopped.class, this::handleSimulationEnd)
                 .build();
+    }
+
+    private void onConfigureSimulation(ConfigureSimulation configure) {
+        logger.info("Configuring benchmark: {}", configure.settings.getName());
+        this.name = configure.settings.getName();
+        this.evaluationsBudget = configure.settings.getEvaluationsBudget();
+        this.simulationSettings = configure.settings;
+        this.simulationActor = sender();
+        init();
     }
 
     private void nextProblem() {
@@ -119,7 +140,7 @@ public class BenchmarkActor extends AbstractActor {
     }
 
     private void checkStopCondition() {
-        if (evaluations == evaluationsBudget) {
+        if (evaluations >= evaluationsBudget) {
             logger.info("Stopping simulation due to evaluation limit reached");
             simulationActor.tell(new StopSimulation(), self());
             runningSimulation = false;
@@ -137,6 +158,11 @@ public class BenchmarkActor extends AbstractActor {
         if (!runningSimulation) {
             runningSimulation = true;
             evaluations = 0;
+
+            // Trigger Hard Reset and set new problemId in SimulationActor
+            ConfigureSimulation configure = new ConfigureSimulation(simulationSettings, benchmarkProblem.getId());
+            simulationActor.tell(configure, self());
+
             StartSimulation startSimulation = new StartSimulation(benchmarkProblem);
             simulationActor.tell(startSimulation, self());
             logger.debug("Sending message to simulationActor {}", startSimulation);
@@ -147,9 +173,9 @@ public class BenchmarkActor extends AbstractActor {
 
     private void handleSimulationEnd(SimulationStopped stopped) {
         logger.info("Simulation has stopped, handling the start of next problem");
-        extractData();
         nextProblem();
-        startSimulation();
+        if (benchmarkProblem != null)
+            startSimulation();
     }
 
     private void extractData() {

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/MainActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/MainActor.java
@@ -31,44 +31,80 @@ public class MainActor extends AbstractActor {
 
     private Server grpcServer;
 
-    @Override
-    public Receive createReceive() {
-        return receiveBuilder()
-                .match(SimulationSettings.class, this::setup)
-                .match(SimulationReady.class, this::onReady)
-                .match(SimulationStopped.class, this::onSimulationStopped)
-                .build();
+    private final int grpcPort;
+
+    public MainActor() {
+        this(8080);
     }
 
-    private void setup(SimulationSettings settings) {
-        logger.info("Setting up the simulation manager");
-        this.settings = settings;
-        if (settings.isBenchmark()) {
-            simulationActor = context().actorOf(Props.create(SimulationActor.class, settings), "manager");
-            benchmarkActor = context().actorOf(Props.create(BenchmarkActor.class, simulationActor, settings.getName(), settings.getEvaluationsBudget()), "benchmark");
+    public MainActor(int grpcPort) {
+        this.grpcPort = grpcPort;
+    }
 
-        } else {
-            simulationActor = context().actorOf(Props.create(SimulationActor.class, settings), "manager");
-        }
+    @Override
+    public void preStart() {
+        logger.info("Main actor starting on port {}", grpcPort);
+        simulationActor = context().actorOf(Props.create(SimulationActor.class), "manager");
+        benchmarkActor = context().actorOf(Props.create(BenchmarkActor.class), "benchmark");
 
         ActorRef agentShard = ClusterSharding.get(context().system()).startProxy(
                 "agents",
                 Optional.empty(),
                 Messages.agentMessageExtractor);
 
-        grpcServer = ServerBuilder.forPort(8080)
+        ActorRef regionShard = ClusterSharding.get(context().system()).startProxy(
+                "regions",
+                Optional.empty(),
+                Messages.regionMessageExtractor);
+
+        grpcServer = ServerBuilder.forPort(grpcPort)
                 .addService(new AgentService(simulationActor, agentShard))
-                .addService(new RegionService(simulationActor))
+                .addService(new RegionService(simulationActor, regionShard))
                 .addService(new BenchmarkService(benchmarkActor))
-                .addService(new SimulationService(simulationActor))
+                .addService(new SimulationService(simulationActor, self()))
                 .build();
 
         try {
             grpcServer.start();
+            logger.info("GRPC server started on port {}", grpcPort);
         } catch (IOException ex) {
             logger.error("Couldn't start grpc endpoint", ex);
         }
-        logger.info("GRPC started");
+    }
+
+    @Override
+    public void postStop() {
+        if (grpcServer != null) {
+            grpcServer.shutdown();
+        }
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .match(SimulationSettings.class, this::setup)
+                .match(ConfigureSimulation.class, this::onConfigureSimulation)
+                .match(SimulationReady.class, this::onReady)
+                .match(SimulationStopped.class, this::onSimulationStopped)
+                .build();
+    }
+
+    private void onConfigureSimulation(ConfigureSimulation configure) {
+        logger.info("Forwarding configuration to manager");
+        this.settings = configure.settings;
+        simulationActor.forward(configure, context());
+        if (settings.isBenchmark()) {
+            benchmarkActor.forward(configure, context());
+        }
+    }
+
+    private void setup(SimulationSettings settings) {
+        logger.info("Setting up the simulation manager");
+        this.settings = settings;
+        simulationActor.tell(new ConfigureSimulation(settings), self());
+        if (settings.isBenchmark()) {
+            benchmarkActor.tell(new ConfigureSimulation(settings), self());
+        }
     }
 
     private void onReady(SimulationReady ready)  {

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/Messages.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/Messages.java
@@ -7,6 +7,7 @@ import br.cefetmg.lsi.bimasco.core.Solution;
 import br.cefetmg.lsi.bimasco.core.solutions.analyser.SolutionAnalyser;
 import br.cefetmg.lsi.bimasco.settings.AgentSettings;
 import br.cefetmg.lsi.bimasco.settings.RegionSettings;
+import br.cefetmg.lsi.bimasco.settings.SimulationSettings;
 import org.apache.commons.math3.stat.descriptive.MultivariateSummaryStatistics;
 import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
@@ -230,15 +231,17 @@ public class Messages {
         }
     }
 
-    public static class StartSimulation implements Serializable {
+    public static class StartSimulation extends AbstractMessage {
 
         public final Optional<Problem> problem;
 
         public StartSimulation(Problem problem) {
+            super(Messages.Nobody, Messages.Nobody);
             this.problem = Optional.ofNullable(problem);
         }
 
         public StartSimulation(){
+            super(Messages.Nobody, Messages.Nobody);
             problem = Optional.empty();
         }
 
@@ -246,6 +249,7 @@ public class Messages {
         public String toString() {
             return "StartSimulation{" +
                     "problem=" + problem +
+                    ", problemId=" + problemId +
                     '}';
         }
     }
@@ -254,7 +258,15 @@ public class Messages {
 
     public static class SimulationReady implements Serializable {}
 
-    public static class StopSimulation implements Serializable {}
+    public static class StopSimulation extends AbstractMessage {
+        public StopSimulation(int receiverId) {
+            super(Messages.Nobody, receiverId);
+        }
+
+        public StopSimulation() {
+            super(Messages.Nobody, Messages.Nobody);
+        }
+    }
     public static class SimulationStopped implements Serializable {
         public final List<ActorRef> nodes;
 
@@ -268,7 +280,11 @@ public class Messages {
 
     public static class GetState extends AbstractMessage {
         public GetState(int receiverId) {
-            super(Messages.Nobody, receiverId);
+            super(Nobody, receiverId);
+        }
+
+        public GetState(int receiverId, String problemId) {
+            super(Nobody, receiverId, problemId);
         }
 
         public GetState() {
@@ -304,6 +320,43 @@ public class Messages {
         }
     }
 
+    public static class ConfigureSimulation implements Serializable {
+        public final SimulationSettings settings;
+        public final String problemId;
+
+        public ConfigureSimulation(SimulationSettings settings) {
+            this(settings, null);
+        }
+
+        public ConfigureSimulation(SimulationSettings settings, String problemId) {
+            this.settings = settings;
+            this.problemId = problemId;
+        }
+    }
+
+    public static class DetailedRegionState implements Serializable {
+        public final String regionId;
+        public final long startedTime;
+        public final long currentTime;
+        public final boolean started;
+        public final long numberOfSolutions;
+        public final double average;
+        public final double std;
+        public final Solution bestSolution;
+
+        public DetailedRegionState(String regionId, long startedTime, long currentTime, boolean started,
+                                   long numberOfSolutions, double average, double std, Solution bestSolution) {
+            this.regionId = regionId;
+            this.startedTime = startedTime;
+            this.currentTime = currentTime;
+            this.started = started;
+            this.numberOfSolutions = numberOfSolutions;
+            this.average = average;
+            this.std = std;
+            this.bestSolution = bestSolution;
+        }
+    }
+
     public static class Terminate implements Serializable {}
 }
 
@@ -335,7 +388,7 @@ class MessageExtractor implements ShardRegion.MessageExtractor {
 
         if (message instanceof AbstractMessage) {
             AbstractMessage abstractMessage = (AbstractMessage) message;
-            shardId = abstractMessage.receiverId % numberOfShards;
+            shardId = Math.abs(abstractMessage.receiverId % numberOfShards);
         } else {
             shardId = 0;
         }
@@ -348,11 +401,22 @@ abstract class AbstractMessage implements Serializable {
     final UUID messageId;
     final int senderId;
     final int receiverId;
+    String problemId;
 
     public AbstractMessage(int senderId, int receiverId) {
+        this(senderId, receiverId, null);
+    }
+
+    public AbstractMessage(int senderId, int receiverId, String problemId) {
         messageId = UUID.randomUUID();
         this.senderId = senderId;
         this.receiverId = receiverId;
+        this.problemId = problemId;
+    }
+
+    public AbstractMessage withProblemId(String problemId) {
+        this.problemId = problemId;
+        return this;
     }
 
     @Override
@@ -361,6 +425,7 @@ abstract class AbstractMessage implements Serializable {
                 "messageId=" + messageId +
                 ", senderId=" + senderId +
                 ", receiverId=" + receiverId +
+                ", problemId=" + problemId +
                 '}';
     }
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/RegionActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/RegionActor.java
@@ -61,6 +61,7 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
     private SimulationSettings settings;
 
     private int id;
+    private String problemId;
 
     private ActorRef leader;
 
@@ -87,6 +88,9 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
     public void preStart() {
         String [] tokens = self().path().name().split("-");
         id = Integer.parseInt(tokens[1]);
+        if (tokens.length > 2) {
+            problemId = tokens[2];
+        }
 
         if (DatabaseHelper.getCqlSession() != null) {
             regionStateDAO = DatabaseHelper.getMapper().regionStateDAO();
@@ -130,18 +134,46 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
                 .match(InternalStimulus.class, this::onInternalStimulus)
                 .match(UpdateGlobalSummary.class, this::onUpdateGlobalSummary)
                 .match(StopSimulation.class, this::onStopSimulation)
+                .match(GetState.class, this::onGetState)
                 .matchAny(any -> logger.info("Not handling " + any.getClass()))
                 .build();
     }
 
+    private void onGetState(GetState state) {
+        if (region == null) {
+            sender().tell(new akka.actor.Status.Failure(new IllegalStateException("Region not initialized")), self());
+            return;
+        }
+
+        double average = region.getSummary().getMean();
+        double std = region.getSummary().getStandardDeviation();
+        long numberOfSolutions = region.getSummary().getN();
+
+        DetailedRegionState detailedRegionState = new DetailedRegionState(
+                persistenceId(),
+                0, // TODO: track started time if needed
+                time,
+                regionStarted,
+                numberOfSolutions,
+                average,
+                std,
+                region.getBestSolution()
+        );
+
+        sender().tell(detailedRegionState, self());
+    }
+
     private void initialize(CreateRegion config) {
+        this.problemId = config.problemId;
         problem = config.problem;
         time = config.time;
         region = new Region(id, config.problem, config.settings);
         leader = sender();
         addSolutions(config.initialSolutions);
 
-        sender().tell(new RegionRegister(id, region.getSummary()), self());
+        RegionRegister register = new RegionRegister(id, region.getSummary());
+        register.withProblemId(problemId);
+        sender().tell(register, self());
 
         InternalStimulus internalStimulusMessage = new InternalStimulus();
         internalStimulusMessage.setInformation(Stimulus.StimulusInformation.CHANGE_MY_STATE);
@@ -173,7 +205,9 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
         internalTask.cancel();
         region.clear();
         regionStarted = false;
-        sender().tell(new RegionRelease(id), self());
+        RegionRelease release = new RegionRelease(id);
+        release.withProblemId(problemId);
+        sender().tell(release, self());
     }
 
 
@@ -190,11 +224,13 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
 
         if (region.getSolutionList().size() > request.counter) {
             List<Solution> solutions = region.getRandomSolutions(request.counter);
-            SolutionResponse response = new SolutionResponse(id, request.receiverId, solutions);
+            SolutionResponse response = new SolutionResponse(id, request.senderId, solutions);
+            response.withProblemId(problemId);
             sender().tell(response, self());
 
             persistMessage(sent(problem.toString(), response, time, persistenceId()));
         }
+
     }
 
     private  void onSolutionResponse(SolutionResponse response) {
@@ -215,6 +251,7 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
 
         if (StatisticsHelper.variationRate(merged) < StatisticsHelper.variationRate(region.getSummary())) {
             MergeResponse response = new MergeResponse(id, request.senderId);
+            response.withProblemId(problemId);
             sender().tell(response, self());
 
             persistMessage(sent(problem.toString(), response, time, persistenceId()));
@@ -227,7 +264,9 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
         if (region != null) {
             logger.info("Region " + persistenceId() + " handling a merge response from " + sender().path().name());
             MergeResult mergeResult = new MergeResult(id, response.senderId, region.getSolutionList());
+            mergeResult.withProblemId(problemId);
             RegionRelease release = new RegionRelease(id);
+            release.withProblemId(problemId);
 
             sender().tell(mergeResult, self());
             leader.tell(release, self());
@@ -264,6 +303,7 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
         persistRegion(regionState());
 
         UpdateRegionSummary updateSummary = new UpdateRegionSummary(id, region.getSummary());
+        updateSummary.withProblemId(problemId);
         leader.tell(updateSummary, self());
         persistMessage(sent(problem.toString(), updateSummary, time, persistenceId()));
     }
@@ -288,6 +328,7 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
 
             if (!splitResult.isEmpty()) {
                 RegionSplit split = new RegionSplit(id, splitResult.get(0), splitResult.get(1));
+                split.withProblemId(problemId);
                 leader.tell(split, self());
 
                 persistMessage(sent(problem.toString(), split, time, persistenceId()));
@@ -297,6 +338,7 @@ public class RegionActor extends AbstractPersistentActor implements Serializable
             } else {
                 MergeRequest mergeRequest = new MergeRequest(id, Messages.Everybody, region.getSummary(),
                         region.getSearchSpaceSummary());
+                mergeRequest.withProblemId(problemId);
                 leader.tell(mergeRequest, self());
                 persistMessage(sent(problem.toString(), mergeRequest, time, persistenceId()));
             }

--- a/src/main/java/br/cefetmg/lsi/bimasco/actors/SimulationActor.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/actors/SimulationActor.java
@@ -75,32 +75,45 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
 
     private long time;
 
+    private String currentProblemId;
+
+    public SimulationActor() {
+        nodes = new ArrayList<>();
+        amILeader = false;
+        simulationStarted = false;
+        status = SimulationState.Status.STOPPED;
+        time = 0;
+        regionsIds = new ArrayList<>();
+        agentsIds = new ArrayList<>();
+        regionUsedIds = new ArrayList<>();
+        agentsUsedIds = new ArrayList<>();
+    }
+
     public SimulationActor(SimulationSettings settings){
+        this();
+        configure(settings);
+    }
+
+    private void configure(SimulationSettings settings) {
+        simulationSettings = settings;
         regionSettings = settings.getRegion();
         agents = new ActorRef[settings.getNumberOfAgents()];
         regions = new ActorRef[regionSettings.getMaxRegions()];
         regionsSummary = new SummaryStatistics[regionSettings.getMaxRegions()];
         globalStatistics = new SummaryStatistics();
-        nodes = new ArrayList<>();
-        simulationSettings = settings;
         problem = Problem.buildProblem(settings.getProblem());
-        amILeader = false;
-        simulationStarted = false;
 
-        regionsIds = new ArrayList<>();
-        agentsIds = new ArrayList<>();
-        regionUsedIds = new ArrayList<>();
-        agentsUsedIds = new ArrayList<>();
-
+        regionsIds.clear();
         for (int i = 0; i < regionSettings.getMaxRegions(); ++i) {
             regionsIds.add(i);
         }
 
+        agentsIds.clear();
         for (int i = 0; i < simulationSettings.getNumberOfAgents(); ++i) {
             agentsIds.add(i);
         }
 
-        time = 0;
+        initializeSharding();
     }
 
 
@@ -111,6 +124,18 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
         logger.info("Joining cluster");
         cluster.subscribe(self(), ClusterEvent.MemberUp.class, ClusterEvent.LeaderChanged.class);
         logger.info("Subscribed to Member events");
+
+        initializeSharding();
+
+        if (DatabaseHelper.getCqlSession() != null) {
+            globalStateDAO = DatabaseHelper.getMapper().globalStateDAO();
+            messageStateDAO = DatabaseHelper.getMapper().messageStateDAO();
+        }
+    }
+
+    private void initializeSharding() {
+        if (simulationSettings == null) return;
+
         ClusterShardingSettings shardSettings = ClusterShardingSettings.create(context().system());
 
         agentShard = ClusterSharding.get(context().system())
@@ -120,11 +145,6 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
         regionShard = ClusterSharding.get(context().system())
                 .start("regions", Props.create(RegionActor.class, simulationSettings), shardSettings,
                         Messages.regionMessageExtractor);
-
-        if (DatabaseHelper.getCqlSession() != null) {
-            globalStateDAO = DatabaseHelper.getMapper().globalStateDAO();
-            messageStateDAO = DatabaseHelper.getMapper().messageStateDAO();
-        }
     }
 
     @Override
@@ -157,6 +177,7 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
                 .match(MergeRequest.class, this::onMergeRequest)
                 .match(RegionRelease.class, this::onRegionRelease)
                 .match(UpdateRegionSummary.class, this::onUpdateRegionSummary)
+                .match(ConfigureSimulation.class, this::onConfigureSimulation)
                 .match(StartSimulation.class, this::onStartSimulation)
                 .match(StopSimulation.class, this::onStopSimulation)
                 .match(GetState.class, this::onGetState)
@@ -164,6 +185,31 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
                 .match(SimulationStopped.class, any -> logger.info("Received simulation stopped"))
                 .matchAny(any -> logger.warn("Not handling {}", any))
                 .build();
+    }
+
+    private void onConfigureSimulation(ConfigureSimulation configure) {
+        logger.info("Configuring simulation: {}", configure.settings.getName());
+        if (simulationSettings != null) {
+            hardReset();
+        }
+
+        this.currentProblemId = configure.problemId != null ? configure.problemId : configure.settings.getName();
+        configure(configure.settings);
+
+        if (nodes.size() == simulationSettings.getNodes()) {
+            createAgents();
+        }
+    }
+
+    private void hardReset() {
+        logger.info("Performing hard reset");
+        stopAgentsAndRegions(new StopSimulation());
+        resetRegionsData();
+        agentsUsedIds.clear();
+        regionUsedIds.clear();
+        time = 0;
+        status = SimulationState.Status.STOPPED;
+        simulationStarted = false;
     }
 
     private void terminate(Terminate t){
@@ -188,17 +234,29 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
     }
 
     private void stopAgentsAndRegions(StopSimulation stopSimulation) {
-        Arrays.stream(agents)
+        String problemId = currentProblemId;
+        List<CompletableFuture<Object>> agentFutures = Arrays.stream(agents)
                 .filter(Objects::nonNull)
-                .map(agent -> Patterns.ask(agent, stopSimulation, Duration.ofSeconds(1)))
-                .map(CompletionStage::toCompletableFuture)
-                .forEach(CompletableFuture::join);
+                .map(agent -> {
+                    StopSimulation stop = new StopSimulation();
+                    stop.withProblemId(problemId);
+                    return Patterns.ask(agent, stop, Duration.ofSeconds(5)).toCompletableFuture();
+                })
+                .collect(Collectors.toList());
 
-        Arrays.stream(regions)
+        List<CompletableFuture<Object>> regionFutures = Arrays.stream(regions)
                 .filter(Objects::nonNull)
-                .map(region -> Patterns.ask(region, stopSimulation, Duration.ofSeconds(1)))
-                .map(CompletionStage::toCompletableFuture)
-                .map(CompletableFuture::join)
+                .map(region -> {
+                    StopSimulation stop = new StopSimulation();
+                    stop.withProblemId(problemId);
+                    return Patterns.ask(region, stop, Duration.ofSeconds(5)).toCompletableFuture();
+                })
+                .collect(Collectors.toList());
+
+        CompletableFuture.allOf(agentFutures.toArray(new CompletableFuture[0])).join();
+        CompletableFuture.allOf(regionFutures.toArray(new CompletableFuture[0])).join();
+
+        regionFutures.stream().map(CompletableFuture::join)
                 .forEach(release -> {
                     if (release instanceof RegionRelease) {
                         onRegionRelease((RegionRelease) release);
@@ -233,7 +291,11 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
         startSimulation.problem.ifPresent(p -> problem = p);
         Arrays.stream(agents)
                 .filter(Objects::nonNull)
-                .forEach(agent -> agent.tell(new StartSimulation(problem), self()));
+                .forEach(agent -> {
+                    StartSimulation start = new StartSimulation(problem);
+                    start.withProblemId(currentProblemId);
+                    agent.tell(start, self());
+                });
         simulationStarted = true;
         sender().tell(new SimulationStarted(), self());
     }
@@ -305,6 +367,7 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
             ActorRef region = regions[i];
             if (region != null) {
                 UpdateGlobalSummary updateGlobalSummary = new UpdateGlobalSummary(i, globalStatistics, time, regionUsedIds);
+                updateGlobalSummary.withProblemId(currentProblemId);
                 logger.debug(format("Sending global update %s to %s", updateGlobalSummary, region));
                 region.tell(updateGlobalSummary, self());
                 persistMessage(sent(problem.toString(), updateGlobalSummary, time, ENTITY_ID));
@@ -321,6 +384,7 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
             ActorRef agent = agents[i];
             if (agent != null) {
                 UpdateGlobalSummary updateGlobalSummary = new UpdateGlobalSummary(i, globalStatistics, time, regionUsedIds);
+                updateGlobalSummary.withProblemId(currentProblemId);
                 agent.tell(updateGlobalSummary, self());
             }
         }
@@ -394,7 +458,9 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
      */
     private void createRegion(Integer id, List<Solution> solutions) {
         logger.info(format("Creating region-%d", id));
-        regionShard.tell(new CreateRegion(id, simulationSettings.getRegion(), time, solutions, problem), self());
+        CreateRegion createRegion = new CreateRegion(id, simulationSettings.getRegion(), time, solutions, problem);
+        createRegion.withProblemId(currentProblemId);
+        regionShard.tell(createRegion, self());
     }
 
     /**
@@ -487,9 +553,13 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
 
         CompletionStage<ActorRef> future = newMemberSelection.resolveOne(Duration.ofSeconds(1));
         future.thenAccept(nodes::add).thenRun(() -> {
-            logger.info("Member {} added. Nodes {}/{}", memberAddress, nodes.size(), simulationSettings.getNodes());
-            if (nodes.size() == simulationSettings.getNodes()) {
-                createAgents();
+            if (simulationSettings != null) {
+                logger.info("Member {} added. Nodes {}/{}", memberAddress, nodes.size(), simulationSettings.getNodes());
+                if (nodes.size() == simulationSettings.getNodes()) {
+                    createAgents();
+                }
+            } else {
+                logger.info("Member {} added. Nodes {}. Waiting for configuration.", memberAddress, nodes.size());
             }
         });
     }
@@ -507,6 +577,7 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
                     if (id.isPresent()) {
                         Integer agentId = id.get();
                         CreateAgent createAgent = new CreateAgent(agentId, agentShard, regionShard, self(), agentSettings);
+                        createAgent.withProblemId(currentProblemId);
                         CompletableFuture t = Patterns.ask(agentShard, createAgent, Duration.ofSeconds(5)).toCompletableFuture();
 
                         completionStages.add(t);
@@ -587,16 +658,17 @@ public class SimulationActor extends AbstractActor implements MessagePersister {
     public void onGetState(GetState getState) {
         SimulationState state = new SimulationState(
                 status,
-                problem.toString(),
+                problem != null ? problem.toString() : "Not Configured",
                 time,
                 simulationSettings,
                 globalStatistics,
-                Arrays.stream(agents).filter(Objects::nonNull).collect(Collectors.toList()),
-                Arrays.stream(regions).filter(Objects::nonNull).collect(Collectors.toList()),
-                IntStream.range(0, regionsSummary.length)
+                agents != null ? Arrays.stream(agents).filter(Objects::nonNull).collect(Collectors.toList()) : List.of(),
+                regions != null ? Arrays.stream(regions).filter(Objects::nonNull).collect(Collectors.toList()) : List.of(),
+                regionsSummary != null ?
+                        IntStream.range(0, regionsSummary.length)
                         .filter(idx -> regionsSummary[idx] != null)
                         .boxed()
-                        .collect(Collectors.toMap(idx -> "region-" + idx, idx -> regionsSummary[(Integer) idx]))
+                        .collect(Collectors.toMap(idx -> "region-" + idx, idx -> regionsSummary[(Integer) idx])) : Map.of()
         );
 
         sender().tell(state, self());

--- a/src/main/java/br/cefetmg/lsi/bimasco/api/AgentService.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/api/AgentService.java
@@ -70,42 +70,50 @@ public class AgentService extends AgentServiceGrpc.AgentServiceImplBase {
         String agentId = request.getAgentId();
         int id = Integer.parseInt(agentId.split("-")[1]);
 
-        Patterns.ask(agentShard, new Messages.GetState(id), Duration.ofSeconds(5))
-                .toCompletableFuture()
-                .thenAccept(obj -> {
-                    if (obj instanceof Messages.DetailedAgentState) {
-                        Messages.DetailedAgentState state = (Messages.DetailedAgentState) obj;
-                        DescribeAgentResponse.Builder builder = DescribeAgentResponse.newBuilder()
-                                .setAgentId(state.agentId)
-                                .setLifetime(state.lifetime)
-                                .setStartTime(state.startTime)
-                                .setCurrentTime(state.currentTime)
-                                .setCompleteExecutions(state.completeExecutions)
-                                .setRequiredSolutions(state.requiredSolutions)
-                                .setHeuristic(state.heuristic)
-                                .setMemoryTax(state.memoryTax)
-                                .putAllMemory(state.qTable.entrySet().stream()
-                                        .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)));
+        getSimulationState().thenAccept(simState -> {
+            String problemId = simState.settings != null ? simState.settings.getName() : null;
 
-                        if (state.bestSolution != null) {
-                            List<Double> x = DoubleStream.of(state.bestSolution.toDoubleArray()).boxed().collect(Collectors.toList());
-                            List<Double> y = List.of(state.bestSolution.getFunctionValue().doubleValue());
+            Patterns.ask(agentShard, new Messages.GetState(id, problemId), Duration.ofSeconds(5))
+                    .toCompletableFuture()
+                    .thenAccept(obj -> {
+                        if (obj instanceof Messages.DetailedAgentState) {
+                            Messages.DetailedAgentState state = (Messages.DetailedAgentState) obj;
+                            DescribeAgentResponse.Builder builder = DescribeAgentResponse.newBuilder()
+                                    .setAgentId(state.agentId)
+                                    .setLifetime(state.lifetime)
+                                    .setStartTime(state.startTime)
+                                    .setCurrentTime(state.currentTime)
+                                    .setCompleteExecutions(state.completeExecutions)
+                                    .setRequiredSolutions(state.requiredSolutions)
+                                    .setHeuristic(state.heuristic)
+                                    .setMemoryTax(state.memoryTax)
+                                    .putAllMemory(state.qTable.entrySet().stream()
+                                            .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)));
 
-                            builder.setBestSolution(Solution.newBuilder()
-                                    .setId(state.bestSolution.getId().toString())
-                                    .addAllX(x)
-                                    .addAllY(y)
-                                    .build());
+                            if (state.bestSolution != null) {
+                                List<Double> x = DoubleStream.of(state.bestSolution.toDoubleArray()).boxed().collect(Collectors.toList());
+                                List<Double> y = List.of(state.bestSolution.getFunctionValue().doubleValue());
+
+                                builder.setBestSolution(Solution.newBuilder()
+                                        .setId(state.bestSolution.getId().toString())
+                                        .addAllX(x)
+                                        .addAllY(y)
+                                        .build());
+                            }
+
+                            responseObserver.onNext(builder.build());
+                            responseObserver.onCompleted();
+                        } else {
+                            responseObserver.onError(new RuntimeException("Unexpected response from agent: " + obj));
                         }
-
-                        responseObserver.onNext(builder.build());
-                        responseObserver.onCompleted();
-                    } else {
-                        responseObserver.onError(new RuntimeException("Unexpected response from agent: " + obj));
-                    }
-                }).exceptionally(ex -> {
-                    responseObserver.onError(ex);
-                    return null;
-                });
+                    }).exceptionally(ex -> {
+                        responseObserver.onError(ex);
+                        return null;
+                    });
+        }).exceptionally(ex -> {
+            responseObserver.onError(ex);
+            return null;
+        });
     }
+
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/api/RegionService.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/api/RegionService.java
@@ -1,25 +1,31 @@
 package br.cefetmg.lsi.bimasco.api;
 
 import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+import br.cefetmg.lsi.bimasco.actors.Messages;
 import br.cefetmg.lsi.bimasco.actors.SimulationState;
 import io.grpc.stub.StreamObserver;
 import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 
 public class RegionService extends RegionServiceGrpc.RegionServiceImplBase {
 
     private static final Logger logger = LoggerFactory.getLogger(RegionService.class);
 
-    private ActorRef simulationActor;
+    private final ActorRef simulationActor;
+    private final ActorRef regionShard;
 
-    public RegionService(ActorRef simulationActor) {
+    public RegionService(ActorRef simulationActor, ActorRef regionShard) {
         this.simulationActor = simulationActor;
+        this.regionShard = regionShard;
     }
 
     private CompletableFuture<SimulationState> getSimulationState() {
@@ -51,7 +57,44 @@ public class RegionService extends RegionServiceGrpc.RegionServiceImplBase {
 
     @Override
     public void describeRegion(DescribeRegionRequest request, StreamObserver<DescribeRegionResponse> responseObserver) {
-        super.describeRegion(request, responseObserver);
+        logger.info("Doptimas API describeRegion request {}", request);
+        String regionId = request.getRegionId();
+        int id = Integer.parseInt(regionId.split("-")[1]);
+
+        Patterns.ask(regionShard, new Messages.GetState(id), Duration.ofSeconds(5))
+                .toCompletableFuture()
+                .thenAccept(obj -> {
+                    if (obj instanceof Messages.DetailedRegionState) {
+                        Messages.DetailedRegionState state = (Messages.DetailedRegionState) obj;
+                        DescribeRegionResponse.Builder builder = DescribeRegionResponse.newBuilder()
+                                .setRegionId(state.regionId)
+                                .setStartedTime(state.startedTime)
+                                .setCurrentTime(state.currentTime)
+                                .setStarted(state.started)
+                                .setNumberOfSolutions(state.numberOfSolutions)
+                                .addObjectiveFunctionAverage(state.average)
+                                .addObjectiveFunctionStd(state.std);
+
+                        if (state.bestSolution != null) {
+                            List<Double> x = DoubleStream.of(state.bestSolution.toDoubleArray()).boxed().collect(Collectors.toList());
+                            List<Double> y = List.of(state.bestSolution.getFunctionValue().doubleValue());
+
+                            builder.setBestSolution(Solution.newBuilder()
+                                    .setId(state.bestSolution.getId().toString())
+                                    .addAllX(x)
+                                    .addAllY(y)
+                                    .build());
+                        }
+
+                        responseObserver.onNext(builder.build());
+                        responseObserver.onCompleted();
+                    } else {
+                        responseObserver.onError(new RuntimeException("Unexpected response from region: " + obj));
+                    }
+                }).exceptionally(ex -> {
+                    responseObserver.onError(ex);
+                    return null;
+                });
     }
 
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/api/SimulationService.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/api/SimulationService.java
@@ -4,6 +4,9 @@ import akka.actor.ActorRef;
 import akka.pattern.Patterns;
 import br.cefetmg.lsi.bimasco.actors.Messages;
 import br.cefetmg.lsi.bimasco.actors.SimulationState;
+import br.cefetmg.lsi.bimasco.settings.SimulationSettings;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +19,11 @@ public class SimulationService extends SimulationServiceGrpc.SimulationServiceIm
     private static final Logger logger = LoggerFactory.getLogger(SimulationService.class);
 
     private final ActorRef simulationActor;
+    private final ActorRef mainActor;
 
-    public SimulationService(ActorRef simulationActor) {
+    public SimulationService(ActorRef simulationActor, ActorRef mainActor) {
         this.simulationActor = simulationActor;
+        this.mainActor = mainActor;
     }
 
     private CompletableFuture<SimulationState> getSimulationState() {
@@ -44,7 +49,20 @@ public class SimulationService extends SimulationServiceGrpc.SimulationServiceIm
     @Override
     public void startSimulation(StartSimulationRequest request, StreamObserver<StatSimulationResponse> responseObserver) {
         logger.info("Doptimas API startSimulation request");
-        
+
+        if (request.getConfigurationFileContent() != null && !request.getConfigurationFileContent().isEmpty()) {
+            try {
+                logger.info("Received configuration content, updating simulation");
+                Config config = ConfigFactory.parseString(request.getConfigurationFileContent());
+                SimulationSettings settings = new SimulationSettings(config);
+                mainActor.tell(new Messages.ConfigureSimulation(settings), ActorRef.noSender());
+            } catch (Exception ex) {
+                logger.error("Error parsing configuration", ex);
+                responseObserver.onError(ex);
+                return;
+            }
+        }
+
         // Wait for SimulationStarted confirmation before getting state
         Patterns.ask(simulationActor, new Messages.StartSimulation(), Duration.ofSeconds(5))
                 .toCompletableFuture()

--- a/src/main/java/br/cefetmg/lsi/bimasco/data/DataExtractionBatch.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/data/DataExtractionBatch.java
@@ -42,6 +42,5 @@ public class DataExtractionBatch {
             extractor.extractData(path);
         }
         logger.info("Finished data extraction successfully");
-        System.exit(0);
     }
 }

--- a/src/main/java/br/cefetmg/lsi/bimasco/data/ExtractorsConfig.java
+++ b/src/main/java/br/cefetmg/lsi/bimasco/data/ExtractorsConfig.java
@@ -103,15 +103,14 @@ public class ExtractorsConfig {
     }
 
     private Set<String> getRegionNames() {
-
-        return regionStateDAO.findAll().all()
+        return regionStateDAO.findByProblem(problemId).all()
                 .stream()
                 .map(RegionState::getName)
                 .collect(Collectors.toSet());
     }
 
     private Set<String> getAgentNames() {
-        return agentStateDAO.findAll().all()
+        return agentStateDAO.findByProblem(problemId).all()
                 .stream()
                 .map(AgentState::getPersistentId)
                 .collect(Collectors.toSet());

--- a/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
+++ b/src/test/java/br/cefetmg/lsi/bimasco/api/AgentServiceTest.java
@@ -92,7 +92,7 @@ public class AgentServiceTest {
         Config config = ConfigFactory.parseString(configString);
         SimulationSettings settings = new SimulationSettings(config);
 
-        ActorRef mainActor = system.actorOf(Props.create(MainActor.class), "main");
+        ActorRef mainActor = system.actorOf(Props.create(MainActor.class, 0), "main");
         mainActor.tell(settings, ActorRef.noSender());
 
         // Wait for SimulationActor to be created by MainActor
@@ -114,7 +114,7 @@ public class AgentServiceTest {
 
         server = ServerBuilder.forPort(0)
                 .addService(new AgentService(simulationActor, agentShard))
-                .addService(new SimulationService(simulationActor))
+                .addService(new SimulationService(simulationActor, mainActor))
                 .build()
                 .start();
 

--- a/src/test/java/br/cefetmg/lsi/bimasco/api/SimulationServiceTest.java
+++ b/src/test/java/br/cefetmg/lsi/bimasco/api/SimulationServiceTest.java
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.cluster.Cluster;
 import akka.testkit.javadsl.TestKit;
+import akka.testkit.TestProbe;
 import br.cefetmg.lsi.bimasco.actors.SimulationActor;
 import br.cefetmg.lsi.bimasco.settings.SimulationSettings;
 import com.typesafe.config.Config;
@@ -60,9 +61,10 @@ public class SimulationServiceTest {
         SimulationSettings settings = new SimulationSettings(config);
 
         simulationActor = system.actorOf(Props.create(SimulationActor.class, settings), "simulationActor");
+        ActorRef mainActorProbe = new TestProbe(system).ref();
 
         server = ServerBuilder.forPort(0)
-                .addService(new SimulationService(simulationActor))
+                .addService(new SimulationService(simulationActor, mainActorProbe))
                 .build()
                 .start();
 


### PR DESCRIPTION
Fixes #19

### Changes
- Refactored `Main` and `MainActor` to support a dormant startup mode, allowing the gRPC server to bind immediately and wait for dynamic configuration.
- Updated `SimulationService` to parse dynamic HOCON configurations via gRPC.
- Improved COCO benchmark isolation by implementing a hard reset in `SimulationActor`, which stops and re-initializes all agents and regions between problems.
- Fixed `AgentService` and implemented `RegionService.describeRegion` to ensure accurate monitoring for `doptctl`.
- Fixed JVM exit bug in `DataExtractionBatch`.
- Updated test suite to prevent port binding conflicts during initialization.